### PR TITLE
[add][BOJ] NQueen : 보드의 좌표 값 계산 방법 적용

### DIFF
--- a/subinLim/BOJ/boj9663_G4_NQueen.py
+++ b/subinLim/BOJ/boj9663_G4_NQueen.py
@@ -1,0 +1,38 @@
+import sys
+input = sys.stdin.readline
+
+# 퀸의 공격 범위 : 상하좌우 + 대각선
+
+N = int(input())
+# 상/하 공격 범위
+visited = [False] * N
+# 왼쪽 상단 대각선/오른쪽 하단 대각선 공격 범위
+visited2 = [False] * (N*2-1)
+# 오른쪽 상단 대각선/왼쪽 하단 대각선 공격 범위
+visited3 = [False] * (N*2-1)
+ans = 0
+
+# depth : 좌/우 공격 범위
+def perm(depth):
+  global ans
+  if depth == N:
+    ans += 1
+    return
+      
+  # 탐색
+  for x in range(N):
+    if visited[x] or visited2[depth - x] or visited3[depth + x]:
+      continue
+    
+    visited[x] = True
+    visited2[depth - x] = True
+    visited3[depth + x] = True
+        
+    perm(depth+1)
+        
+    visited[x] = False
+    visited2[depth - x] = False
+    visited3[depth + x] = False
+      
+perm(0)
+print(ans)


### PR DESCRIPTION
처음에 퀸의 공격 범위를 잘못 설정해 델타 탐색으로 풀이하려고 했습니다.
(상하좌우 + 대각선 1칸 씩의 범위 설정)

다른 풀이와 선생님의 풀이를 참고해 공격 범위를 깨닫고 보드의 좌표 값을 이용한 풀이를 진행했습니다.
- `depth` : 좌우 공격 범위
- `visited` : 상하 공격 범위
- `visited2` : 퀸의 왼쪽 상단 대각선과 오른쪽 하단 대각선의 공격 가능한 범위
- `visited3` : 퀸의 오른쪽 상단 대각선과 왼쪽 하단 대각선의 공격 가능한 범위
![depth o](https://github.com/user-attachments/assets/9319ed41-4406-4124-86d8-10088777a2da)
